### PR TITLE
Add support for a Markdown Contact Us page

### DIFF
--- a/app-config.js
+++ b/app-config.js
@@ -51,11 +51,11 @@ export const SAMVERA_PARTNERS = [
     label: "Hyku for Consortia (PALNI & PALCI)",
     href: "#",
   },
-   {
+  {
     label: "Indiana University",
     href: "#",
   },
-   {
+  {
     label: "Lafayette College",
     href: "#",
   },
@@ -63,83 +63,83 @@ export const SAMVERA_PARTNERS = [
     label: "Northwestern University",
     href: "#",
   },
-   {
+  {
     label: "Oregon State University",
     href: "#",
   },
-   {
+  {
     label: "Penn State University",
     href: "#",
   },
-   {
+  {
     label: "Princeton University",
     href: "#",
   },
-   {
+  {
     label: "Software Services by Scientist.com",
     href: "#",
   },
-   {
+  {
     label: "Stanford University",
     href: "#",
   },
-   {
+  {
     label: "Tufts University",
     href: "#",
   },
-   {
+  {
     label: "Ubiquity Press",
     href: "#",
   },
-   {
+  {
     label: "University of California, Santa Barbara",
     href: "#",
   },
-   {
+  {
     label: "University of California, San Diego",
     href: "#",
   },
-   {
+  {
     label: "University of Cincinnati",
     href: "#",
   },
-   {
+  {
     label: "University of Houston",
     href: "#",
   },
-   {
+  {
     label: "University of Hull",
     href: "#",
   },
-   {
+  {
     label: "University of Michigan",
     href: "#",
   },
-   {
+  {
     label: "University of Notre Dame",
     href: "#",
   },
-   {
+  {
     label: "University of Oregon",
     href: "#",
   },
-   {
+  {
     label: "University of Utah",
     href: "#",
   },
-   {
+  {
     label: "University of Virginia",
     href: "#",
   },
-   {
+  {
     label: "Washington University in St. Louis",
     href: "#",
   },
-   {
+  {
     label: "WGBH Boston",
     href: "#",
   },
-   {
+  {
     label: "Yale University",
     href: "#",
   },
@@ -147,7 +147,7 @@ export const SAMVERA_PARTNERS = [
 
 export const sideBarLinks = [
   {
-    href: "contact-us",
+    href: "/contact-us",
     label: "Contact Us",
   },
   {

--- a/lib/build-nav.js
+++ b/lib/build-nav.js
@@ -24,9 +24,9 @@ function getNavMap() {
   const directories = fs.readdirSync("markdown");
   directories.forEach((directory) => {
     /**
-     * Exclude creating navigation for Home and News
+     * Exclude creating navigation for Home, Contact and News
      */
-    if (!["home", "news"].includes(directory)) {
+    if (!["home", "contact-us", "news"].includes(directory)) {
       const files = fs.readdirSync(`markdown/${directory}`);
       const navItems = files.map((fileName) => {
         const slug = fileName.replace(".md", "");

--- a/markdown/contact-us/index.md
+++ b/markdown/contact-us/index.md
@@ -1,0 +1,6 @@
+---
+title: "Contact Us"
+date: "2023-02-28"
+---
+
+Contact info goes here...

--- a/pages/contact-us/index.jsx
+++ b/pages/contact-us/index.jsx
@@ -1,0 +1,49 @@
+import DynamicPage from "components/layout/DynamicPage";
+import { getMarkdownPageContent, getSideNav } from "lib/markdown-helpers";
+import { buildWorkOpenGraphData } from "lib/open-graph";
+
+const CONFIG = {
+  parentDir: "contact-us",
+  parentDirLabel: "Contact Us",
+};
+
+export default function ContactPage({
+  content,
+  frontmatter,
+  sideNav,
+  sideNewsAndEvents,
+}) {
+  return (
+    <DynamicPage
+      config={CONFIG}
+      content={content}
+      frontmatter={frontmatter}
+      sideNav={sideNav}
+      sideNewsAndEvents={sideNewsAndEvents}
+    />
+  );
+}
+
+export async function getStaticProps() {
+  const { content, frontmatter } = getMarkdownPageContent(
+    `markdown/${CONFIG.parentDir}/index.md`
+  );
+  const { sideNav } = getSideNav(`markdown/${CONFIG.parentDir}`);
+  const { sideNav: sideNewsAndEvents } = getSideNav(`markdown/news`);
+
+  const openGraphData = buildWorkOpenGraphData(
+    CONFIG.parentDirLabel,
+    frontmatter.title,
+    `${CONFIG.parentDir}`
+  );
+
+  return {
+    props: {
+      content,
+      frontmatter,
+      openGraphData,
+      sideNav,
+      sideNewsAndEvents,
+    },
+  };
+}

--- a/site-navigation.js
+++ b/site-navigation.js
@@ -1,2 +1,130 @@
-
-export const siteNavigation=[{"label":"about","items":[{"href":"/about/governance","label":"Governance and Philosophy","slug":"governance"},{"href":"/about/interest-working-groups","label":"Interest and Working Groups","slug":"interest-working-groups"},{"href":"/about/licensing","label":"Licensing","slug":"licensing"},{"href":"/about/philosophy","label":"Philosophy","slug":"philosophy"},{"href":"/about/samvera-2021-annual-report","label":"Annual Report","slug":"samvera-2021-annual-report"},{"href":"/about/samvera-code-of-conduct-and-anti-harassment-policy","label":"Samvera Code of Conduct and Anti-Harassment Policy","slug":"samvera-code-of-conduct-and-anti-harassment-policy"},{"href":"/about/samvera-community-sourced-software","label":"Samvera is Community Sourced Software for Repository Solutions","slug":"samvera-community-sourced-software"}],"slug":"about"},{"label":"getting started","items":[{"href":"/getting-started/faq","label":"FAQ","slug":"faq"},{"href":"/getting-started/getting-started","label":"Getting started","slug":"getting-started"}],"slug":"getting-started"},{"label":"what is samvera","items":[{"href":"/what-is-samvera/applications-demos","label":"Applications & Demos","slug":"applications-demos"},{"href":"/what-is-samvera/samvera-open-source-repository-framework","label":"Samvera is an Open Source Repository Framework","slug":"samvera-open-source-repository-framework"},{"href":"/what-is-samvera/technology-stack","label":"Technology stack","slug":"technology-stack"}],"slug":"what-is-samvera"},{"label":"who uses samvera","items":[{"href":"/who-uses-samvera/case-studies","label":"Case study: Emory University","slug":"case-studies"},{"href":"/who-uses-samvera/case-study-avalon-at-the-university-of-houston","label":"Case Study: Avalon at the University of Houston","slug":"case-study-avalon-at-the-university-of-houston"},{"href":"/who-uses-samvera/community-framework","label":"Community Framework","slug":"community-framework"},{"href":"/who-uses-samvera/samvera-adopters","label":"Samvera Adopters","slug":"samvera-adopters"},{"href":"/who-uses-samvera/samvera-partners","label":"Samvera Partners","slug":"samvera-partners"},{"href":"/who-uses-samvera/samvera-user-profiles","label":"Samvera user profiles","slug":"samvera-user-profiles"},{"href":"/who-uses-samvera/take-a-tour-of-active-samvera-repositories","label":"Samvera Repository Tour","slug":"take-a-tour-of-active-samvera-repositories"}],"slug":"who-uses-samvera"},{"label":"why use samvera","items":[{"href":"/why-use-samvera/peer-support","label":"Community Support","slug":"peer-support"},{"href":"/why-use-samvera/samvera-flexible-extensible","label":"Samvera is Flexible and Extensible","slug":"samvera-flexible-extensible"},{"href":"/why-use-samvera/sustainability","label":"Sustainability","slug":"sustainability"},{"href":"/why-use-samvera/the-samvera-community","label":"The Samvera Community","slug":"the-samvera-community"}],"slug":"why-use-samvera"}];
+export const siteNavigation = [
+  {
+    label: "about",
+    items: [
+      { href: "/about/faq", label: "FAQ", slug: "faq" },
+      {
+        href: "/about/governance",
+        label: "Governance and Philosophy",
+        slug: "governance",
+      },
+      {
+        href: "/about/interest-working-groups",
+        label: "Interest and Working Groups",
+        slug: "interest-working-groups",
+      },
+      { href: "/about/licensing", label: "Licensing", slug: "licensing" },
+      { href: "/about/philosophy", label: "Philosophy", slug: "philosophy" },
+      {
+        href: "/about/samvera-2021-annual-report",
+        label: "Annual Report",
+        slug: "samvera-2021-annual-report",
+      },
+      {
+        href: "/about/samvera-code-of-conduct-and-anti-harassment-policy",
+        label: "Samvera Code of Conduct and Anti-Harassment Policy",
+        slug: "samvera-code-of-conduct-and-anti-harassment-policy",
+      },
+      {
+        href: "/about/samvera-community-sourced-software",
+        label: "Samvera is Community Sourced Software for Repository Solutions",
+        slug: "samvera-community-sourced-software",
+      },
+    ],
+    slug: "about",
+  },
+  {
+    label: "getting started",
+    items: [
+      {
+        href: "/getting-started/getting-started",
+        label: "Getting started",
+        slug: "getting-started",
+      },
+    ],
+    slug: "getting-started",
+  },
+  {
+    label: "what is samvera",
+    items: [
+      {
+        href: "/what-is-samvera/applications-demos",
+        label: "Applications & Demos",
+        slug: "applications-demos",
+      },
+      {
+        href: "/what-is-samvera/samvera-open-source-repository-framework",
+        label: "Samvera is an Open Source Repository Framework",
+        slug: "samvera-open-source-repository-framework",
+      },
+      {
+        href: "/what-is-samvera/technology-stack",
+        label: "Technology stack",
+        slug: "technology-stack",
+      },
+    ],
+    slug: "what-is-samvera",
+  },
+  {
+    label: "who uses samvera",
+    items: [
+      {
+        href: "/who-uses-samvera/case-studies",
+        label: "Case study: Emory University",
+        slug: "case-studies",
+      },
+      {
+        href: "/who-uses-samvera/case-study-avalon-at-the-university-of-houston",
+        label: "Case Study: Avalon at the University of Houston",
+        slug: "case-study-avalon-at-the-university-of-houston",
+      },
+      {
+        href: "/who-uses-samvera/community-framework",
+        label: "Community Framework",
+        slug: "community-framework",
+      },
+      {
+        href: "/who-uses-samvera/samvera-adopters",
+        label: "Samvera Adopters",
+        slug: "samvera-adopters",
+      },
+      {
+        href: "/who-uses-samvera/samvera-partners",
+        label: "Samvera Partners",
+        slug: "samvera-partners",
+      },
+      {
+        href: "/who-uses-samvera/samvera-user-profiles",
+        label: "Samvera user profiles",
+        slug: "samvera-user-profiles",
+      },
+      {
+        href: "/who-uses-samvera/take-a-tour-of-active-samvera-repositories",
+        label: "Samvera Repository Tour",
+        slug: "take-a-tour-of-active-samvera-repositories",
+      },
+    ],
+    slug: "who-uses-samvera",
+  },
+  {
+    label: "why use samvera",
+    items: [
+      {
+        href: "/why-use-samvera/samvera-flexible-extensible",
+        label: "Samvera is Flexible and Extensible",
+        slug: "samvera-flexible-extensible",
+      },
+      {
+        href: "/why-use-samvera/sustainability",
+        label: "Sustainability",
+        slug: "sustainability",
+      },
+      {
+        href: "/why-use-samvera/the-samvera-community",
+        label: "The Samvera Community",
+        slug: "the-samvera-community",
+      },
+    ],
+    slug: "why-use-samvera",
+  },
+];


### PR DESCRIPTION
@heathergreerklein This will follow the normal convention of just adding content for the Contact Us page into `/markdown/contact-us`.  Feel free to add whatever you like...