### PR TITLE
Update styles to support Markdown elements

### DIFF
--- a/components/BannerPartners.jsx
+++ b/components/BannerPartners.jsx
@@ -1,11 +1,11 @@
-import { SAMVERA_PARTNERS } from "app-config";
 import Link from "next/link";
+import { SAMVERA_PARTNERS } from "app-config";
 
 export default function BannerPartners() {
   return (
     <section className="flex flex-col items-center justify-center p-10 bg-samBlue">
       <h3 className="pb-8 title">Samvera Partners</h3>
-      <ul className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
+      <ul className="grid grid-cols-2 gap-4 ml-0 list-none md:grid-cols-3 lg:grid-cols-4">
         {SAMVERA_PARTNERS.map((partner) => (
           <li key={partner.label} className="px-4 md:px-8 lg:px-10">
             <Link

--- a/components/Breadcrumbs.jsx
+++ b/components/Breadcrumbs.jsx
@@ -1,10 +1,10 @@
+import Link from "next/link";
 import PropTypes from "prop-types";
 import React from "react";
-import Link from "next/link";
 
 const Breadcrumbs = ({ items }) => {
   return (
-    <ul className="mt-8 mb-6 flex">
+    <ul className="flex pb-0 mt-8 mb-6 ml-0 list-none">
       {items.map((item, index) => (
         <li
           key={index}

--- a/components/MarkdownContent.jsx
+++ b/components/MarkdownContent.jsx
@@ -1,19 +1,21 @@
 /**
  * Good reference for how to parse markdown w/ HTML
  * https://unifiedjs.com/learn/recipe/remark-html/
+ * https://unifiedjs.com/explore/package/hast-util-sanitize/#defaultschema
  */
 
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
+
 import React from "react";
+import deepmerge from "deepmerge";
 import md from "markdown-it";
+import rehypeRaw from "rehype-raw";
+import rehypeStringify from "rehype-stringify";
 import { remark } from "remark";
 import remarkHtml from "remark-html";
 import remarkParse from "remark-parse";
-import { unified } from "unified";
 import remarkRehype from "remark-rehype";
-import rehypeStringify from "rehype-stringify";
-import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
-import deepmerge from "deepmerge";
-import rehypeRaw from "rehype-raw";
+import { unified } from "unified";
 
 export default function MarkdownContent({ content }) {
   const [processedContent, setProcessedContent] = React.useState();

--- a/components/home/CommunityNewsEvents.jsx
+++ b/components/home/CommunityNewsEvents.jsx
@@ -1,12 +1,12 @@
-import React from "react";
 import Link from "next/link";
+import React from "react";
 import { prefix } from "prefix";
 
 export default function CommunityNewsEvents({ items }) {
   return (
     <section className="bg-none md:bg-community-news">
-      <div className="container px-0 md:px-4 max-w-full">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-12">
+      <div className="container max-w-full px-0 md:px-4">
+        <div className="grid grid-cols-1 gap-12 md:grid-cols-3">
           <div className="p-10 md:col-span-2">
             <h2 className="section-title">The Samvera Community</h2>
             <p>
@@ -38,7 +38,7 @@ export default function CommunityNewsEvents({ items }) {
             style={{ backgroundImage: `url(${prefix}/images/news-bg.jpeg)` }}
           >
             <h2 className="section-title">News &amp; Events</h2>
-            <ul>
+            <ul className="ml-0 list-none">
               {items.map((item) => (
                 <li key={item.slug} className="mb-3">
                   <Link legacyBehavior href={`/news/${item.slug}`}>

--- a/components/layout/Main.jsx
+++ b/components/layout/Main.jsx
@@ -1,9 +1,5 @@
 import React from "react";
 
 export default function Main({ children }) {
-  return (
-    <main className="bg-samBlueLight">
-      <div className="">{children}</div>
-    </main>
-  );
+  return <main className="pb-4">{children}</main>;
 }

--- a/markdown/getting-started/getting-started.md
+++ b/markdown/getting-started/getting-started.md
@@ -21,8 +21,6 @@ If you have unique needs that are not represented on the Hyrax feature list, do 
 
 You can find some instructional documentation in [our knowledge base](http://samvera.github.io/index.html). The [samvera-tech mailing list](https://groups.google.com/forum/#!forum/samvera-tech/join) is a good resource, as is the #dev channel on Samvera Slack. Official Samvera code repositories are in the Samvera [Github organization](https://github.com/samvera), and emerging projects are in samvera\-labs. You might also consider attending a Samvera Camp or Advanced Samvera Camp for face-to-face instruction.
 
- 
-
 ### Samvera for Managers
 
 Forthcoming.

--- a/styles/global.css
+++ b/styles/global.css
@@ -7,8 +7,8 @@ a {
 }
 main button,
 .button {
-  /* @apply inline-block font-fontinBold uppercase bg-samBlue text-samGreyDark text-center py-3 px-8; */
-  @apply w-full md:w-auto flex items-center justify-center px-8 py-3 border border-transparent font-fontinBold rounded-md text-samGreyDark hover:text-white bg-samBlue hover:bg-samDarkRed md:py-4 md:text-lg md:px-10 transition ease-in-out duration-200;
+  /* @apply inline-block px-8 py-3 text-center uppercase font-fontinBold bg-samBlue text-samGreyDark; */
+  @apply flex items-center justify-center w-full px-8 py-3 transition duration-200 ease-in-out border border-transparent rounded-md md:w-auto font-fontinBold text-samGreyDark hover:text-white bg-samBlue hover:bg-samDarkRed md:py-4 md:text-lg md:px-10;
 }
 .button-inverted {
   @apply button bg-white hover:text-samGreyDark !important;
@@ -19,7 +19,7 @@ h3,
 h4,
 h5,
 h6 {
-  @apply uppercase font-fontin mb-3;
+  @apply mb-3 uppercase font-fontin;
 }
 h1 {
   @apply text-3xl font-fontinBold;
@@ -37,21 +37,27 @@ main a {
   @apply text-samDarkRed hover:text-samOrange;
 }
 p {
-  @apply mb-4 leading-loose;
+  @apply pb-4 leading-loose;
 }
-/* main ul {
-  @apply list-disc ml-4;
-} */
+main ul {
+  @apply pb-2 ml-5 list-disc;
+}
 main li {
-  @apply pb-2;
+  @apply leading-loose;
+}
+main li ul {
+  @apply pb-0;
+}
+strong {
+  @apply font-fontinBold;
 }
 
 .ul-disc {
-  @apply list-disc ml-4;
+  @apply ml-4 list-disc;
 }
 
 .section-title {
-  @apply mt-3 mr-0 mb-7 uppercase text-center md:text-3xl xl:text-4xl;
+  @apply mt-3 mr-0 text-center uppercase mb-7 md:text-3xl xl:text-4xl;
 }
 
 .sidebar a:hover {


### PR DESCRIPTION
Related to #47 

@heathergreerklein I put some notes in the issue, but most of these "not working" markdown elements are due to our TailwindCSS reset being applied, and some related to the font.   I updated the main styles (headlines, lists, italic, bold, etc), and if there are more you're trying to use which aren't working, just let me know.

![image](https://github.com/samvera/samvera.org/assets/3020266/d3a23e6b-bf24-471f-b9e1-cb219d07f94f)


