### PR TITLE
Typo Software fix and Getting Started link fix

### DIFF
--- a/components/home/CommunityNewsEvents.jsx
+++ b/components/home/CommunityNewsEvents.jsx
@@ -28,7 +28,7 @@ export default function CommunityNewsEvents({ items }) {
               bundles.
             </p>
             <div className="flex justify-around pt-5">
-              <Link legacyBehavior href="/getting-started/getting-started">
+              <Link legacyBehavior href="/getting-started">
                 <a className="button">Getting started</a>
               </Link>
             </div>

--- a/components/home/Hero.jsx
+++ b/components/home/Hero.jsx
@@ -23,13 +23,16 @@ export default function HomeHero() {
 
           <div className="mt-10 sm:flex sm:justify-center lg:justify-start">
             <div className="rounded-md shadow">
-              <Link legacyBehavior href="/getting-started/getting-started">
-                <a className="button">Get started</a>
+              <Link className="button" href="/getting-started">
+                Get started
               </Link>
             </div>
             <div className="mt-3 rounded-md shadow sm:mt-0 sm:ml-3">
-              <Link legacyBehavior href="/what-is-samvera/applications-demos">
-                <a className="button-inverted">Learn more</a>
+              <Link
+                className="button-inverted"
+                href="/what-is-samvera/applications-demos"
+              >
+                Learn more
               </Link>
             </div>
           </div>

--- a/components/layout/HeaderNew.jsx
+++ b/components/layout/HeaderNew.jsx
@@ -35,7 +35,7 @@ const newsNavigation = [
 
 const softwareSolutionsNavigation = [
   {
-    label: "Sofware Solutions",
+    label: "Software Solutions",
     slug: "",
     items: [
       {

--- a/components/layout/OuterWrapper.jsx
+++ b/components/layout/OuterWrapper.jsx
@@ -3,7 +3,7 @@ import React from "react";
 export default function OuterWrapper({ children }) {
   return (
     <div className="border-t-2 bg-gradient-to-br from-transparent to-samBlueLight border-samDarkRed">
-      <div className="container mx-auto">{children}</div>
+      <div className="container mx-auto max-w-7xl">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
## What does this do?

Update link to Get Started parent page, and fix typo in Software Solutions nav header

<img width="1359" alt="image" src="https://github.com/samvera/samvera.org/assets/3020266/5fd7ff7e-1225-4561-984c-63f59db8b332">
